### PR TITLE
Renamed name output to fqdn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Nullstone Block standing up a subdomain in AWS Route53 for each environment.
 
 ## Outputs
 
-- `name: string` - The created subdomain.
+- `name: string` - The name that precedes the domain name for the created subdomain.
+- `fqdn: string` - The FQDN (fully-qualified domain name) for the created subdomain.
 - `zone_id: string` - The zone ID of the AWS Route53 Zone for the created subdomain.
 - `nameservers: list(string)` - The list of nameservers of the AWS Route53 Zone for the created subdomain.
 - `domain_name: string` - The name of the root domain.
-- `domain_zeon_id: string` - The zone ID of the root domain.
+- `domain_zone_id: string` - The zone ID of the root domain.
 - `cert_arn: string` - If var.create_cert is enabled, the ARN of the SSL Certificate.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,11 @@
 output "name" {
+  value       = var.subdomain
+  description = "string ||| The name that precedes the domain name for the created subdomain."
+}
+
+output "fqdn" {
   value       = aws_route53_zone.this.name
-  description = "string ||| The created subdomain."
+  description = "string ||| The FQDN (fully-qualified domain name) for the created subdomain."
 }
 
 output "zone_id" {


### PR DESCRIPTION
This PR renames the `name` output to `fqdn`.
The `name` output name represents the part preceding `domain_name`.